### PR TITLE
Added gzip compression

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,8 @@
 .metadata
 bin/
 tmp/
+*.bag
+*.bag.gz
 *.tmp
 *.bak
 *.swp

--- a/src/main/java/badlog/lib/BadLog.java
+++ b/src/main/java/badlog/lib/BadLog.java
@@ -1,7 +1,6 @@
 package badlog.lib;
 
-import java.io.FileWriter;
-import java.io.IOException;
+import java.io.*;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
@@ -10,278 +9,302 @@ import java.util.Optional;
 import java.util.StringJoiner;
 import java.util.function.Function;
 import java.util.function.Supplier;
+import java.util.zip.GZIPOutputStream;
 
 import org.json.simple.JSONArray;
 import org.json.simple.JSONObject;
 
 public class BadLog {
 
-	/**
-	 * The unit to use when the data does not have a unit.
-	 */
-	public static final String UNITLESS = "ul";
-	public static final String DEFAULT_DATA = Double.toString(-1.0);
+    /**
+     * The unit to use when the data does not have a unit.
+     */
+    public static final String UNITLESS = "ul";
+    public static final String DEFAULT_DATA = Double.toString(-1.0);
 
-	private static Optional<BadLog> instance = Optional.empty();
+    private static Optional<BadLog> instance = Optional.empty();
 
-	private boolean registerMode;
+    private boolean registerMode;
 
-	private List<NamespaceObject> namespace;
-	private HashMap<String, Optional<String>> publishedData;
-	private List<Topic> topics;
+    private List<NamespaceObject> namespace;
+    private HashMap<String, Optional<String>> publishedData;
+    private List<Topic> topics;
 
-	private FileWriter fileWriter;
+    FileOutputStream file;
+    private BufferedWriter fileWriter;
+    private GZIPOutputStream gzFile;
 
-	private Function<Double, String> doubleStringFunction = (d) -> String.format("%.5g", d);
+    private Function<Double, String> doubleStringFunction = (d) -> String.format("%.5g", d);
 
-	private BadLog(String path) {
-		registerMode = true;
-		namespace = new ArrayList<>();
-		topics = new ArrayList<>();
-		publishedData = new HashMap<>();
-		try {
-			fileWriter = new FileWriter(path);
-		} catch (IOException e) {
-			e.printStackTrace();
-		}
-	}
+    private BadLog(String path, Boolean compress) {
+        registerMode = true;
+        namespace = new ArrayList<>();
+        topics = new ArrayList<>();
+        publishedData = new HashMap<>();
+        if (compress) {
+            try {
+                file = new FileOutputStream(new File(path + ".gz"));
+                gzFile = new GZIPOutputStream(file, true);
+                fileWriter = new BufferedWriter(new OutputStreamWriter(gzFile, "UTF-8"));
+            } catch (IOException e) {
+                e.printStackTrace();
+            }
+        } else if (!compress) {
+            try {
+                file = new FileOutputStream(new File(path));
+                fileWriter = new BufferedWriter(new OutputStreamWriter(file));
+            } catch (IOException e) {
+                e.printStackTrace();
+            }
+        } else {
+            System.err.println("Error creating fileWriter");
+        }
 
-	/**
-	 * Initializes BadLog.
-	 * @param path of bag file
-	 * @return the instance of BadLog
-	 * @throws RuntimeException if already initialized
-	 */
-	public static BadLog init(String path) {
-		if (instance.isPresent())
-			throw new RuntimeException();
+    }
 
-		BadLog badLog = new BadLog(path);
-		instance = Optional.of(badLog);
+    /**
+     * Initializes BadLog.
+     *
+     * @param path of bag file
+     * @return the instance of BadLog
+     * @throws RuntimeException if already initialized
+     */
+       public static BadLog init(String path, Boolean compress) {
+        if (instance.isPresent())
+            throw new RuntimeException();
 
-		return badLog;
-	}
+        BadLog badLog = new BadLog(path, compress);
+        instance = Optional.of(badLog);
 
-	/**
-	 * Creates a topic that logs Strings.
-	 * @param name
-	 * @param unit
-	 * @param supplier the function to be called to return the logged data
-	 * @param attrs array of topic attributes
-	 */
-	public static void createTopicStr(String name, String unit, Supplier<String> supplier, String... attrs) {
-		if (!instance.get().registerMode)
-			throw new InvalidModeException();
-		if (isInNamespace(name))
-			throw new DuplicateNameException();
+        return badLog;
+    }
 
-		instance.get().checkName(name);
+    public static BadLog init(String path) {
+        return init(path, true);
+    }
 
-		QueriedTopic topic = new QueriedTopic(name, unit, supplier, attrs);
-		instance.get().namespace.add(topic);
-		instance.get().topics.add(topic);
-	}
 
-	/**
-	 * Creates a topic that logs doubles.
-	 * 
-	 * Doubles are converted to strings based on the doubleToString function.
-	 * 
-	 * @param name
-	 * @param unit
-	 * @param supplier the function to be called to return the logged data
-	 * @param attrs array of topic attributes
-	 */
-	public static void createTopic(String name, String unit, Supplier<Double> supplier, String... attrs) {
-		BadLog instance = BadLog.instance.get();
-		createTopicStr(name, unit, () -> instance.doubleStringFunction.apply(supplier.get()), attrs);
-	}
 
-	/**
-	 * Creates a subscribed topic.
-	 * @param name
-	 * @param unit
-	 * @param dataInferMode the method to use if data has not been published
-	 * @param attrs array of topic attributes
-	 */
-	public static void createTopicSubscriber(String name, String unit, DataInferMode dataInferMode, String... attrs) {
-		if (!instance.get().registerMode)
-			throw new InvalidModeException();
-		if (isInNamespace(name))
-			throw new DuplicateNameException();
+    /**
+     * Creates a topic that logs Strings.
+     *
+     * @param name
+     * @param unit
+     * @param supplier the function to be called to return the logged data
+     * @param attrs    array of topic attributes
+     */
+    public static void createTopicStr(String name, String unit, Supplier<String> supplier, String... attrs) {
+        if (!instance.get().registerMode)
+            throw new InvalidModeException();
+        if (isInNamespace(name))
+            throw new DuplicateNameException();
 
-		instance.get().checkName(name);
+        instance.get().checkName(name);
 
-		instance.get().publishedData.put(name, Optional.empty());
-		SubscribedTopic topic = new SubscribedTopic(name, unit, dataInferMode, attrs);
-		instance.get().namespace.add(topic);
-		instance.get().topics.add(topic);
-	}
+        QueriedTopic topic = new QueriedTopic(name, unit, supplier, attrs);
+        instance.get().namespace.add(topic);
+        instance.get().topics.add(topic);
+    }
 
-	/**
-	 * Creates a named value.
-	 * @param name
-	 * @param value
-	 */
-	public static void createValue(String name, String value) {
-		if (!instance.get().registerMode)
-			throw new InvalidModeException();
-		if (isInNamespace(name))
-			throw new DuplicateNameException();
+    /**
+     * Creates a topic that logs doubles.
+     * <p>
+     * Doubles are converted to strings based on the doubleToString function.
+     *
+     * @param name
+     * @param unit
+     * @param supplier the function to be called to return the logged data
+     * @param attrs    array of topic attributes
+     */
+    public static void createTopic(String name, String unit, Supplier<Double> supplier, String... attrs) {
+        BadLog instance = BadLog.instance.get();
+        createTopicStr(name, unit, () -> instance.doubleStringFunction.apply(supplier.get()), attrs);
+    }
 
-		instance.get().checkName(name);
+    /**
+     * Creates a subscribed topic.
+     *
+     * @param name
+     * @param unit
+     * @param dataInferMode the method to use if data has not been published
+     * @param attrs         array of topic attributes
+     */
+    public static void createTopicSubscriber(String name, String unit, DataInferMode dataInferMode, String... attrs) {
+        if (!instance.get().registerMode)
+            throw new InvalidModeException();
+        if (isInNamespace(name))
+            throw new DuplicateNameException();
 
-		instance.get().namespace.add(new Value(name, value));
-	}
+        instance.get().checkName(name);
 
-	/**
-	 * Publish a string to a topic.
-	 * @param name
-	 * @param value
-	 */
-	public static void publish(String name, String value) {
-		BadLog tmp = instance.get();
-		if (tmp.registerMode)
-			throw new InvalidModeException();
-		tmp.recievePublishedData(name, value);
-	}
+        instance.get().publishedData.put(name, Optional.empty());
+        SubscribedTopic topic = new SubscribedTopic(name, unit, dataInferMode, attrs);
+        instance.get().namespace.add(topic);
+        instance.get().topics.add(topic);
+    }
 
-	/**
-	 * Publish a double to a topic.
-	 * @param name
-	 * @param value
-	 */
-	public static void publish(String name, double value) {
-		publish(name, instance.get().doubleStringFunction.apply(value));
-	}
+    /**
+     * Creates a named value.
+     *
+     * @param name
+     * @param value
+     */
+    public static void createValue(String name, String value) {
+        if (!instance.get().registerMode)
+            throw new InvalidModeException();
+        if (isInNamespace(name))
+            throw new DuplicateNameException();
 
-	/**
-	 * Closes the logger for any new values or topics.
-	 * Prints bag file headers.
-	 */
-	public void finishInitialization() {
-		if (!registerMode)
-			throw new InvalidModeException();
-		registerMode = false;
+        instance.get().checkName(name);
 
-		String jsonHeader = genJsonHeader();
+        instance.get().namespace.add(new Value(name, value));
+    }
 
-		// CSV Header
-		StringJoiner joiner = new StringJoiner(",");
-		topics.stream().map(Topic::getName).forEach((n) -> joiner.add(n));
-		String header = joiner.toString();
+    /**
+     * Publish a string to a topic.
+     *
+     * @param name
+     * @param value
+     */
+    public static void publish(String name, String value) {
+        BadLog tmp = instance.get();
+        if (tmp.registerMode)
+            throw new InvalidModeException();
+        tmp.recievePublishedData(name, value);
+    }
 
-		writeLine(jsonHeader);
-		writeLine(header);
+    /**
+     * Publish a double to a topic.
+     *
+     * @param name
+     * @param value
+     */
+    public static void publish(String name, double value) {
+        publish(name, instance.get().doubleStringFunction.apply(value));
+    }
 
-		try {
-			fileWriter.flush();
-		} catch (IOException e) {
-			e.printStackTrace();
-		}
-	}
+    /**
+     * Closes the logger for any new values or topics.
+     * Prints bag file headers.
+     */
+    public void finishInitialization() {
+        if (!registerMode)
+            throw new InvalidModeException();
+        registerMode = false;
 
-	@SuppressWarnings("unchecked")
-	private String genJsonHeader() {
-		JSONObject jsonRoot = new JSONObject();
+        String jsonHeader = genJsonHeader();
 
-		JSONArray jsonTopics = new JSONArray();
-		for (Topic t : topics) {
-			JSONObject topic = new JSONObject();
-			topic.put("name", t.getName());
-			topic.put("unit", t.getUnit());
-			JSONArray attrs = new JSONArray();
-			Arrays.stream(t.getAttributes()).forEach((a) -> attrs.add(a));
-			topic.put("attrs", attrs);
-			jsonTopics.add(topic);
-		}
+        // CSV Header
+        StringJoiner joiner = new StringJoiner(",");
+        topics.stream().map(Topic::getName).forEach((n) -> joiner.add(n));
+        String header = joiner.toString();
 
-		jsonRoot.put("topics", jsonTopics);
+        writeLine(jsonHeader);
+        writeLine(header);
 
-		JSONArray jsonValues = new JSONArray();
-		namespace.stream().filter((o) -> o instanceof Value).map((v) -> (Value) v).forEach((v) -> {
-			JSONObject value = new JSONObject();
-			value.put("name", v.getName());
-			value.put("value", v.getValue());
-			jsonValues.add(value);
-		});
+    }
 
-		jsonRoot.put("values", jsonValues);
+    @SuppressWarnings("unchecked")
+    private String genJsonHeader() {
+        JSONObject jsonRoot = new JSONObject();
 
-		return jsonRoot.toJSONString();
-	}
+        JSONArray jsonTopics = new JSONArray();
+        for (Topic t : topics) {
+            JSONObject topic = new JSONObject();
+            topic.put("name", t.getName());
+            topic.put("unit", t.getUnit());
+            JSONArray attrs = new JSONArray();
+            Arrays.stream(t.getAttributes()).forEach((a) -> attrs.add(a));
+            topic.put("attrs", attrs);
+            jsonTopics.add(topic);
+        }
 
-	/**
-	 * Query all queried topics and process published data.
-	 * 
-	 * This must be called before each call to log
-	 */
-	public void updateTopics() {
-		if (registerMode)
-			throw new InvalidModeException();
+        jsonRoot.put("topics", jsonTopics);
 
-		topics.stream().filter((o) -> o instanceof QueriedTopic).map((o) -> (QueriedTopic) o)
-				.forEach(QueriedTopic::refreshValue);
+        JSONArray jsonValues = new JSONArray();
+        namespace.stream().filter((o) -> o instanceof Value).map((v) -> (Value) v).forEach((v) -> {
+            JSONObject value = new JSONObject();
+            value.put("name", v.getName());
+            value.put("value", v.getValue());
+            jsonValues.add(value);
+        });
 
-		topics.stream().filter((o) -> o instanceof SubscribedTopic).map((o) -> (SubscribedTopic) o)
-				.forEach((t) -> t.handlePublishedData(publishedData.get(t.getName())));
+        jsonRoot.put("values", jsonValues);
 
-		publishedData.replaceAll((k, v) -> Optional.empty());
-	}
+        return jsonRoot.toJSONString();
+    }
 
-	/**
-	 * Write the values of each topic to the bag file.
-	 */
-	public void log() {
-		if (registerMode)
-			throw new InvalidModeException();
+    /**
+     * Query all queried topics and process published data.
+     * <p>
+     * This must be called before each call to log
+     */
+    public void updateTopics() {
+        if (registerMode)
+            throw new InvalidModeException();
 
-		StringJoiner joiner = new StringJoiner(",");
-		topics.stream().map(Topic::getValue).map(BadLog::escapeCommas).forEach((v) -> joiner.add(v));
-		String line = joiner.toString();
+        topics.stream().filter((o) -> o instanceof QueriedTopic).map((o) -> (QueriedTopic) o)
+                .forEach(QueriedTopic::refreshValue);
 
-		writeLine(line);
-	}
+        topics.stream().filter((o) -> o instanceof SubscribedTopic).map((o) -> (SubscribedTopic) o)
+                .forEach((t) -> t.handlePublishedData(publishedData.get(t.getName())));
 
-	public void setDoubleToStringFunction(Function<Double, String> function) {
-		this.doubleStringFunction = function;
-	}
+        publishedData.replaceAll((k, v) -> Optional.empty());
+    }
 
-	private static String escapeCommas(String in) {
-		if (in.contains(",")) {
-			return "\"" + in + "\"";
-		}
-		return in;
-	}
+    /**
+     * Write the values of each topic to the bag file.
+     */
+    public void log() {
+        if (registerMode)
+            throw new InvalidModeException();
 
-	private static boolean isInNamespace(String name) {
-		return instance.get().namespace.stream().anyMatch((o) -> o.getName().equals(name));
-	}
+        StringJoiner joiner = new StringJoiner(",");
+        topics.stream().map(Topic::getValue).map(BadLog::escapeCommas).forEach((v) -> joiner.add(v));
+        String line = joiner.toString();
 
-	private void recievePublishedData(String name, String value) {
-		if (publishedData.get(name) == null)
-			throw new NullPointerException();
+        writeLine(line);
+    }
 
-		publishedData.put(name, Optional.of(value));
-	}
+    public void setDoubleToStringFunction(Function<Double, String> function) {
+        this.doubleStringFunction = function;
+    }
 
-	private void checkName(String name) {
-		for (char c : name.toCharArray()) {
-			if (Character.isLetterOrDigit(c) || c == ' ' || c == '_' || c == '/')
-				continue;
+    private static String escapeCommas(String in) {
+        if (in.contains(",")) {
+            return "\"" + in + "\"";
+        }
+        return in;
+    }
 
-			// Don't crash or throw exception, probably won't cause errors
-			System.out.println("Invalid character " + c + " in name " + name);
-			return;
-		}
-	}
+    private static boolean isInNamespace(String name) {
+        return instance.get().namespace.stream().anyMatch((o) -> o.getName().equals(name));
+    }
 
-	private void writeLine(String line) {
-		try {
-			fileWriter.write(line + System.lineSeparator());
-			fileWriter.flush();
-		} catch (IOException e) {
-			e.printStackTrace();
-		}
-	}
+    private void recievePublishedData(String name, String value) {
+        if (publishedData.get(name) == null)
+            throw new NullPointerException();
+
+        publishedData.put(name, Optional.of(value));
+    }
+
+    private void checkName(String name) {
+        for (char c : name.toCharArray()) {
+            if (Character.isLetterOrDigit(c) || c == ' ' || c == '_' || c == '/')
+                continue;
+
+            // Don't crash or throw exception, probably won't cause errors
+            System.out.println("Invalid character " + c + " in name " + name);
+            return;
+        }
+    }
+
+    private void writeLine(String lines) {
+        try {
+            fileWriter.write(lines + System.lineSeparator());
+            fileWriter.flush();
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
+    }
 }

--- a/src/main/java/badlog/lib/BadLog.java
+++ b/src/main/java/badlog/lib/BadLog.java
@@ -80,7 +80,7 @@ public class BadLog {
     }
 
     public static BadLog init(String path) {
-        return init(path, true);
+        return init(path, false);
     }
 
 


### PR DESCRIPTION
Gzip compression significantly decreases file sizes because of repeated text in CSVs and similar files. On the test this resulted in half the file size compared to the not-compressed counterpart. If you increase the amount of times the test runs, the  compressed file will be around three times smaller than the non-compressed one. Added an option to the init method to disable, if the flag is not set it will default to compressing. To decompress run `zcat file.bag.gz > file.bag`. 

A couple of downsides to this:
Windows machines need 7zip or equivalent to decompress.
Because the stream is constant and needs to be ready for a hard shutdown at any point, there is no way to check if the file isn't corrupted (hence the, `unexpected end of file` error). 
